### PR TITLE
Update printcore.py

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -295,7 +295,7 @@ class printcore():
                 # callback for temp, status, whatever
                 try: self.listener(line)
                 except: self.logError(traceback.format_exc())
-            if line.startswith('ok') and "T:" in line and self.tempcb:
+            if (line.startswith('ok') and "T:" in line or line.startswith('T:')) and self.tempcb:
                 # callback for temp, status, whatever
                 try: self.tempcb(line)
                 except: self.logError(traceback.format_exc())


### PR DESCRIPTION
Temperatur-opdateringer under M109 starter ikke med 'ok', da printeren ikke har udført en kommando. Ellers er de på samme form.